### PR TITLE
Bugfix/hilt library

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.mashup">
 
     <application
+        android:name=".MashUpApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
### 상황
  - 앱 실행이 안됨

###  원인
  - 힐트 라이브러리 적용 후 메니페스트에 어플리케이션 태그를 등록하지 않음

### 대응
  - 메니페스트에 어플리케이션 태그를 추가

### 참조
  -