### PR TITLE
fix: gradle setting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,19 @@
 plugins {
     id 'com.android.application'
+    id 'com.google.gms.google-services'
+    id 'com.google.firebase.crashlytics'
     id 'kotlin-android'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
 }
 
 android {
-    compileSdk compileSdk
+    compileSdk 31
 
     defaultConfig {
         applicationId "com.mashup"
-        minSdk minSdk
-        targetSdk targetSdk
+        minSdk 23
+        targetSdk 31
         versionCode 1
         versionName "1.0.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,12 +8,12 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdkVersion compileVersion
 
     defaultConfig {
         applicationId "com.mashup"
-        minSdk 23
-        targetSdk 31
+        minSdkVersion minVersion
+        targetSdkVersion targetVersion
         versionCode 1
         versionName "1.0.0"
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,6 +2,10 @@ ext {
     // Android
     androidBuildToolsVersion = "7.0.2"
 
+    minVersion = 23
+    targetVersion = 31
+    compileVersion = 31
+
     // androidx
     appcompatVersion = "1.4.1"
     coreKtxVersion = "1.7.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,14 +1,11 @@
 ext {
     // Android
     androidBuildToolsVersion = "7.0.2"
-    minSdk = 23
-    targetSdk = 31
-    compileSdk = 31
 
     // androidx
     appcompatVersion = "1.4.1"
     coreKtxVersion = "1.7.0"
-    activityKtxVersion = "1.4.1"
+    activityKtxVersion = "1.4.0"
     fragmentKtxVersion = "1.4.1"
     lifecycleVersion = "2.5.0-alpha03"
     constraintLayoutVersion = "2.1.3"


### PR DESCRIPTION
### 상황
  - `dependencies.gradle`에 있는 minSdk,targetSdk, compileSdk 동작이 이뤄지지 않아 실행이 되지 않음
  `Cause: compileSdkVersion is not specified. Please add it to build.gradle` 발생
- activityKtx 버전 "1.4.1" 를 불러올 수 없음

###  원인
  - activityKtx 버전은 1.4.0 이 최신이였음
  - compileSdkVersion 에 들어갈 버전 변수를 저장 못하는 것으로 파악

### 대응
  - activityKtx 버전 "1.4.1"  을 "1.4.0" 으로 다운그레이드
  -  minSdk,targetSdk, compileSdk  변수 제거 , 밖으로 꺼냄 

### 참조
  - https://developer.android.com/jetpack/androidx/releases/activity?hl=ko